### PR TITLE
setting scope (and attributes) of validate_hostname

### DIFF
--- a/openssl/openssl_hostname_validation.h
+++ b/openssl/openssl_hostname_validation.h
@@ -9,7 +9,9 @@
  * License: See LICENSE
  *
  */
- 
+#ifndef openssl_hostname_validation_h
+#define openssl_hostname_validation_h
+
 typedef enum {
 	MatchFound,
 	MatchNotFound,
@@ -30,3 +32,5 @@ typedef enum {
 * Returns Error if there was an error.
 */
 HostnameValidationResult validate_hostname(const char *hostname, const X509 *server_cert);
+
+#endif

--- a/openssl/openssl_hostname_validation.h
+++ b/openssl/openssl_hostname_validation.h
@@ -12,6 +12,10 @@
 #ifndef openssl_hostname_validation_h
 #define openssl_hostname_validation_h
 
+#ifndef OPENSSL_HOSTNAME_VALIDATION_LINKAGE
+#define OPENSSL_HOSTNAME_VALIDATION_LINKAGE extern
+#endif
+
 typedef enum {
 	MatchFound,
 	MatchNotFound,
@@ -31,6 +35,6 @@ typedef enum {
 * Returns MalformedCertificate if any of the hostnames had a NUL character embedded in it.
 * Returns Error if there was an error.
 */
-HostnameValidationResult validate_hostname(const char *hostname, const X509 *server_cert);
+OPENSSL_HOSTNAME_VALIDATION_LINKAGE HostnameValidationResult validate_hostname(const char *hostname, const X509 *server_cert);
 
 #endif


### PR DESCRIPTION
Thank you for providing this useful library.

We would like to use it at part of our web server (ref: https://github.com/h2o/h2o/pull/875), but we do not like having `validate_hostname` as an extern function, since users of the web server as a library may have a function with the same name already defined.

To accommodate the issue, this PR adds a macro named `OPENSSL_HOSTNAME_VALIDATION_LINKAGE` that can be used to set the scope as well as other attributes to the function.  The default is set to `extern`, so it does not break existing code.

FWIW, we are going to use it like https://github.com/h2o/h2o/pull/875/commits/d08e9bc627fd7f389b01d2205fca402aa62696ad.
