### PR TITLE
add support for wildcard certificate

### DIFF
--- a/openssl/openssl_hostname_validation.c
+++ b/openssl/openssl_hostname_validation.c
@@ -20,7 +20,7 @@
 
 #define HOSTNAME_MAX_SIZE 255
 
-static int tolower(int ch) {
+static int lowercase(int ch) {
 	if ('A' <= ch && ch <= 'Z')
 		return ch - 'A' + 'a';
 	return ch;
@@ -30,7 +30,7 @@ static int memeq_ncase(const char *x, const char *y, size_t l) {
 	if (l == 0)
 		return 1;
 	do {
-		if (tolower(*x++) != tolower(*y++))
+		if (lowercase(*x++) != lowercase(*y++))
 			return 0;
 	} while (--l != 0);
 	return 1;

--- a/openssl/openssl_hostname_validation.c
+++ b/openssl/openssl_hostname_validation.c
@@ -54,10 +54,13 @@ static HostnameValidationResult validate_name(const char *hostname, ASN1_STRING 
 	if (has_nul(certname_s, certname_len)) {
 		return MalformedCertificate;
 	}
+	// remove last '.' from hostname
+	if (hostname_len != 0 && hostname[hostname_len - 1] == '.')
+		--hostname_len;
+	// Compare expected hostname with the DNS name
 	if (certname_len != hostname_len) {
 		return MatchNotFound;
 	}
-	// Compare expected hostname with the DNS name
 	return memeq_ncase(hostname, certname_s, hostname_len) ? MatchFound : MatchNotFound;
 }
 

--- a/openssl/openssl_hostname_validation.c
+++ b/openssl/openssl_hostname_validation.c
@@ -57,6 +57,18 @@ static HostnameValidationResult validate_name(const char *hostname, ASN1_STRING 
 	// remove last '.' from hostname
 	if (hostname_len != 0 && hostname[hostname_len - 1] == '.')
 		--hostname_len;
+	// skip the first segment if wildcard
+	if (certname_len > 2 && certname_s[0] == '*' && certname_s[1] == '.') {
+		if (hostname_len != 0) {
+			do {
+				--hostname_len;
+				if (*hostname++ == '.')
+					break;
+			} while (hostname_len != 0);
+		}
+		certname_s += 2;
+		certname_len -= 2;
+	}
 	// Compare expected hostname with the DNS name
 	if (certname_len != hostname_len) {
 		return MatchNotFound;


### PR DESCRIPTION
This PR adds support for wildcard certificates (note: only supports CN/dNSName that starts with `*.`).

It also
- stops using strcasecmp to avoid locale-related issues
- stops using str\* functions for testing ASN1 strings (not guranteed to be terminated, see https://www.openssl.org/docs/man1.0.2/crypto/ASN1_STRING_length.html)
- ignores `.` at the end of the supplied hostname if exists, so that for example supplied hostname `www.example.com.` matches against a certificate with CN=`www.example.com`

relates to #10
